### PR TITLE
Add option for disable animation while scrolling

### DIFF
--- a/Sources/Updaters/UICollectionViewUpdater.swift
+++ b/Sources/Updaters/UICollectionViewUpdater.swift
@@ -2,8 +2,12 @@ import UIKit
 
 /// An updater for managing diffing updates to render data to the `UICollectionView`.
 open class UICollectionViewUpdater<Adapter: Carbon.Adapter & UICollectionViewDelegate & UICollectionViewDataSource>: Updater {
-    /// A Bool value indicating whether that enable diffing animations. Default is true.
+    /// A Bool value indicating whether that enable diffing animation. Default is true.
     open var isAnimationEnabled = true
+
+    /// A Bool value indicating whether that enable diffing animation while target is
+    /// scrolling. Default is false.
+    open var isAnimationEnabledWhileScrolling = true
 
     /// A Bool value indicating whether that skips reload components. Default is false.
     open var skipReloadComponents = false
@@ -143,7 +147,7 @@ open class UICollectionViewUpdater<Adapter: Carbon.Adapter & UICollectionViewDel
             }
         }
 
-        if isAnimationEnabled {
+        if isAnimationEnabled && (!target._isScrolling || isAnimationEnabledWhileScrolling) {
             performAnimatedUpdates()
         }
         else {

--- a/Sources/Updaters/UITableViewUpdater.swift
+++ b/Sources/Updaters/UITableViewUpdater.swift
@@ -20,8 +20,12 @@ open class UITableViewUpdater<Adapter: Carbon.Adapter & UITableViewDelegate & UI
     /// An animation for row reloads. Default is fade.
     open var reloadRowsAnimation = UITableView.RowAnimation.fade
 
-    /// A Bool value indicating whether that enable diffing animations. Default is true.
+    /// A Bool value indicating whether that enable diffing animation. Default is true.
     open var isAnimationEnabled = true
+
+    /// A Bool value indicating whether that enable diffing animation while target is
+    /// scrolling. Default is false.
+    open var isAnimationEnabledWhileScrolling = true
 
     /// A Bool value indicating whether that skips reload components. Default is false.
     open var skipReloadComponents = false
@@ -170,7 +174,7 @@ open class UITableViewUpdater<Adapter: Carbon.Adapter & UITableViewDelegate & UI
             }
         }
 
-        if isAnimationEnabled {
+        if isAnimationEnabled && (!target._isScrolling || isAnimationEnabledWhileScrolling) {
             performAnimatedUpdates()
         }
         else {


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description
Add option for disable animation while scrolling.

## Related Issue
None

## Motivation and Context
For example, it's useful in the case that elements are inserted by load more by scroll reached bottom.

## Impact on Existing Code
None
