### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Following are part of it.
 
 - **shouldContentUpdate**  
 If the result is `true`, the component displayed as a cell is reloaded individually, header or footer is reloaded with entire section.  
-It can be omitted by conforming to `Equitable`.  
+It can be omitted by conforming to `Equatable`.  
 
 - **shouldRender**  
 By returning `false`, you can skip component re-rendering when reloading or dequeuing element.  

--- a/Sources/AnyComponent.swift
+++ b/Sources/AnyComponent.swift
@@ -59,7 +59,7 @@ public struct AnyComponent: Component {
 
     /// Returns a `Bool` value indicating whether the content should be reloaded.
     ///
-    /// - Note: Unlike `Equitable`, this doesn't compare whether the two values
+    /// - Note: Unlike `Equatable`, this doesn't compare whether the two values
     ///         exactly equal. It's can be ignore property comparisons, if not expect
     ///         to reload content.
     ///

--- a/Sources/Component.swift
+++ b/Sources/Component.swift
@@ -58,7 +58,7 @@ public protocol Component {
 
     /// Returns a `Bool` value indicating whether the content should be reloaded.
     ///
-    /// - Note: Unlike `Equitable`, this doesn't compare whether the two values
+    /// - Note: Unlike `Equatable`, this doesn't compare whether the two values
     ///         exactly equal. It's can be ignore property comparisons, if not expect
     ///         to reload content.
     ///

--- a/docs/Protocols/Component.html
+++ b/docs/Protocols/Component.html
@@ -388,7 +388,7 @@
                         <p>Returns a <code>Bool</code> value indicating whether the content should be reloaded.</p>
 <div class="aside aside-note">
     <p class="aside-title">Note</p>
-    <p>Unlike <code>Equitable</code>, this doesn&rsquo;t compare whether the two values
+    <p>Unlike <code>Equatable</code>, this doesn&rsquo;t compare whether the two values
     exactly equal. It&rsquo;s can be ignore property comparisons, if not expect
     to reload content.</p>
 

--- a/docs/Structs/AnyComponent.html
+++ b/docs/Structs/AnyComponent.html
@@ -393,7 +393,7 @@
                         <p>Returns a <code>Bool</code> value indicating whether the content should be reloaded.</p>
 <div class="aside aside-note">
     <p class="aside-title">Note</p>
-    <p>Unlike <code>Equitable</code>, this doesn&rsquo;t compare whether the two values
+    <p>Unlike <code>Equatable</code>, this doesn&rsquo;t compare whether the two values
     exactly equal. It&rsquo;s can be ignore property comparisons, if not expect
     to reload content.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -549,7 +549,7 @@ Following are part of it.  </p>
 <ul>
 <li><p><strong>shouldContentUpdate</strong><br>
 If the result is <code>true</code>, the component displayed as a cell is reloaded individually, header or footer is reloaded with entire section.<br>
-It can be omitted by conforming to <code>Equitable</code>.  </p></li>
+It can be omitted by conforming to <code>Equatable</code>.  </p></li>
 <li><p><strong>shouldRender</strong><br>
 By returning <code>false</code>, you can skip component re-rendering when reloading or dequeuing element.<br>
 You can re-render only when component is changed, if implement to call <code>shouldContentUpdate</code> within here.<br>


### PR DESCRIPTION
"Equitable" => "Equatable" ? 🤔 

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description

Thank you all for creating such an awesome library!
I fixed some typos on document.

