### PR TITLE
Fix typo

### DIFF
--- a/Sources/Interfaces/UITableViewComponentHeaderFooterView.swift
+++ b/Sources/Interfaces/UITableViewComponentHeaderFooterView.swift
@@ -29,7 +29,7 @@ open class UITableViewComponentHeaderFooterView: UITableViewHeaderFooterView, Co
     open override func prepareForReuse() {
         super.prepareForReuse()
 
-        renderedViewContent?.viwDidPrepareForReuse(self)
+        renderedViewContent?.viewDidPrepareForReuse(self)
     }
 
     /// Called after the content is rendered on `self`.

--- a/Sources/Interfaces/UITableViewHeaderFooterViewContent.swift
+++ b/Sources/Interfaces/UITableViewHeaderFooterViewContent.swift
@@ -22,7 +22,7 @@ public protocol UITableViewHeaderFooterViewContent {
     ///
     /// - Parameter:
     ///   - view: An instance of view rendering `self`.
-    func viwDidPrepareForReuse(_ view: UITableViewHeaderFooterView)
+    func viewDidPrepareForReuse(_ view: UITableViewHeaderFooterView)
 }
 
 public extension UITableViewHeaderFooterViewContent {
@@ -42,5 +42,5 @@ public extension UITableViewHeaderFooterViewContent {
     ///
     /// - Parameter:
     ///   - view: An instance of view rendering `self`.
-    func viwDidPrepareForReuse(_ view: UITableViewHeaderFooterView) {}
+    func viewDidPrepareForReuse(_ view: UITableViewHeaderFooterView) {}
 }

--- a/Tests/TestTools.swift
+++ b/Tests/TestTools.swift
@@ -421,7 +421,7 @@ final class MockTableViewHeaderFooterViewContent: UITableViewHeaderFooterViewCon
     var viewCapturedOnDidRender: UITableViewHeaderFooterView?
     var viewCapturedOnDidRenderComponent: UITableViewHeaderFooterView?
 
-    func viwDidPrepareForReuse(_ view: UITableViewHeaderFooterView) {
+    func viewDidPrepareForReuse(_ view: UITableViewHeaderFooterView) {
         viewCapturedOnPrepareForReuse = view
     }
 


### PR DESCRIPTION
Just a fix for a minor typo I found.

`viwDidPrepareForReuse` -> `viewDidPrepareForReuse`

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  