### PR TITLE
Deprecate closure style render function

### DIFF
--- a/Sources/AnyComponent.swift
+++ b/Sources/AnyComponent.swift
@@ -156,42 +156,42 @@ internal protocol AnyComponentBox {
 @usableFromInline
 internal struct ComponentBox<Base: Component>: AnyComponentBox {
     @usableFromInline
-    internal let baseComponent: Base
+    let baseComponent: Base
 
     @inlinable
-    internal var base: Any {
+    var base: Any {
         return baseComponent
     }
 
     @inlinable
-    internal var reuseIdentifier: String {
+    var reuseIdentifier: String {
         return baseComponent.reuseIdentifier
     }
 
     @inlinable
-    internal init(_ base: Base) {
+    init(_ base: Base) {
         baseComponent = base
     }
 
     @inlinable
-    internal func renderContent() -> Any {
+    func renderContent() -> Any {
         return baseComponent.renderContent()
     }
 
     @inlinable
-    internal func render(in content: Any) {
+    func render(in content: Any) {
         guard let content = content as? Base.Content else { return }
 
         baseComponent.render(in: content)
     }
 
     @inlinable
-    internal func referenceSize(in bounds: CGRect) -> CGSize? {
+    func referenceSize(in bounds: CGRect) -> CGSize? {
         return baseComponent.referenceSize(in: bounds)
     }
 
     @inlinable
-    internal func layout(content: Any, in container: UIView) {
+    func layout(content: Any, in container: UIView) {
         guard let content = content as? Base.Content else { return }
 
         baseComponent.layout(content: content, in: container)
@@ -212,14 +212,14 @@ internal struct ComponentBox<Base: Component>: AnyComponentBox {
     }
 
     @inlinable
-    internal func contentWillDisplay(_ content: Any) {
+    func contentWillDisplay(_ content: Any) {
         guard let content = content as? Base.Content else { return }
 
         baseComponent.contentWillDisplay(content)
     }
 
     @inlinable
-    internal func contentDidEndDisplay(_ content: Any) {
+    func contentDidEndDisplay(_ content: Any) {
         guard let content = content as? Base.Content else { return }
 
         baseComponent.contentDidEndDisplay(content)

--- a/Sources/Renderer.swift
+++ b/Sources/Renderer.swift
@@ -102,6 +102,7 @@ open class Renderer<Updater: Carbon.Updater> {
     ///
     /// - Parameters:
     ///   - buildData: A closure to build sections.
+    @available(*, deprecated, message: "This method will be removed next version owing to avoid ambiguity with new syntax using function builder.")
     open func render(_ buildData: (inout [Section]) -> Void) {
         var data = [Section]()
         buildData(&data)

--- a/Sources/Section.swift
+++ b/Sources/Section.swift
@@ -69,6 +69,7 @@ public struct Section {
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - buildSection: A closure to build section.
+    @available(*, deprecated, message: "This method will be removed next version owing to avoid ambiguity with new syntax using function builder.")
     @inlinable
     public init<I: Hashable>(id: I, _ buildSection: (inout Section) -> Void) {
         var section = Section(id: id)

--- a/Tests/RendererTests.swift
+++ b/Tests/RendererTests.swift
@@ -156,6 +156,7 @@ final class RendererTests: XCTestCase {
         XCTAssertEqual(renderer.updater.adapterCapturedOnUpdates, adapter)
     }
 
+    @available(*, deprecated)
     func testRenderWithBuilderClosure() {
         let target = MockTarget()
         let adapter = MockAdapter()

--- a/Tests/SectionTests.swift
+++ b/Tests/SectionTests.swift
@@ -33,6 +33,7 @@ final class SectionTests: XCTestCase {
         XCTAssertEqual(section.cells.count, 2)
     }
 
+    @available(*, deprecated)
     func testInitWithBuilderClosure() {
         let section = Section(id: TestID.a) { section in
             section.header = ViewNode(A.Component())


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Deprecate the closure style `Renderer.render` function to avoid new declarative syntax using function builder in next version.