### PR TITLE
Make `keepsContentOffset` set true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Default is `300`.
 Indicating whether that to reset content offset after updated.  
 The content offset become unintended position after diffing updates in some case.
  If set `true`, revert content offset after updates.  
-Default is `false`.  
+Default is `true`.  
 
 [See more](https://ra1028.github.io/Carbon/Updaters.html)
 

--- a/Sources/Updaters/UICollectionViewUpdater.swift
+++ b/Sources/Updaters/UICollectionViewUpdater.swift
@@ -14,8 +14,8 @@ open class UICollectionViewUpdater<Adapter: UICollectionViewAdapter>: Updater {
     open var alwaysRenderVisibleComponents = true
 
     /// A Bool value indicating whether that to reset content offset after
-    /// updated if not scrolling. Default is false.
-    open var keepsContentOffset = false
+    /// updated if not scrolling. Default is true.
+    open var keepsContentOffset = true
 
     /// Max number of changes that can be animated for diffing updates. Default is 300.
     open var animatableChangeCount = 300

--- a/Sources/Updaters/UITableViewUpdater.swift
+++ b/Sources/Updaters/UITableViewUpdater.swift
@@ -32,8 +32,8 @@ open class UITableViewUpdater<Adapter: UITableViewAdapter>: Updater {
     open var alwaysRenderVisibleComponents = true
 
     /// A Bool value indicating whether that to reset content offset after
-    /// updated if not scrolling. Default is false.
-    open var keepsContentOffset = false
+    /// updated if not scrolling. Default is true.
+    open var keepsContentOffset = true
 
     /// Max number of changes that can be animated for diffing updates. Default is 300.
     open var animatableChangeCount = 300

--- a/docs/Classes/UICollectionViewUpdater.html
+++ b/docs/Classes/UICollectionViewUpdater.html
@@ -296,7 +296,7 @@ after diffing updated. Default is true.</p>
                       <div class="pointer"></div>
                       <div class="abstract">
                         <p>A Bool value indicating whether that to reset content offset after
-updated if not scrolling. Default is false.</p>
+updated if not scrolling. Default is true.</p>
 
                       </div>
                       <div class="declaration">

--- a/docs/Classes/UITableViewUpdater.html
+++ b/docs/Classes/UITableViewUpdater.html
@@ -458,7 +458,7 @@ after diffing updated. Default is true.</p>
                       <div class="pointer"></div>
                       <div class="abstract">
                         <p>A Bool value indicating whether that to reset content offset after
-updated if not scrolling. Default is false.</p>
+updated if not scrolling. Default is true.</p>
 
                       </div>
                       <div class="declaration">

--- a/docs/index.html
+++ b/docs/index.html
@@ -614,7 +614,7 @@ Default is <code>300</code>.  </p></li>
 Indicating whether that to reset content offset after updated.<br>
 The content offset become unintended position after diffing updates in some case.
 If set <code>true</code>, revert content offset after updates.<br>
-Default is <code>false</code>.  </p></li>
+Default is <code>true</code>.  </p></li>
 </ul>
 
 <p><a href="https://ra1028.github.io/Carbon/Updaters.html">See more</a></p>


### PR DESCRIPTION
close https://github.com/ra1028/Carbon/issues/45

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Setting false to Updater's keepsContentOffset by default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ra1028/Carbon/issues/45

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The offset will wrong in case content size is changed by deletion and insertion.
