### PR TITLE
[WIP] Enable self-sizing for component in SwiftUI

### DIFF
--- a/Examples/Example-iOS/Sources/Kyoto/KyotoLicense.swift
+++ b/Examples/Example-iOS/Sources/Kyoto/KyotoLicense.swift
@@ -11,10 +11,6 @@ struct KyotoLicense: Component, View {
     func render(in content: KyotoLicenseContent) {
         content.onSelected = onSelected
     }
-
-    func referenceSize(in bounds: CGRect) -> CGSize? {
-        CGSize(width: bounds.size.width, height: 71)
-    }
 }
 
 final class KyotoLicenseContent: UIControl, NibLoadable {

--- a/Examples/Example-iOS/Sources/KyotoSwiftUI/KyotoSwiftUIView.swift
+++ b/Examples/Example-iOS/Sources/KyotoSwiftUI/KyotoSwiftUIView.swift
@@ -5,7 +5,6 @@ struct KyotoSwiftUIView: View {
         ScrollView {
             VStack {
                 KyotoTop()
-                    .frame(height: 435)
 
                 Header("PHOTOS")
 


### PR DESCRIPTION
## TODO
- [x] Enable self-sizing
- [ ] Remove `Component.intrinsicContentSize(for:)` added in RC5

## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
SwiftUI can't support self-sizing, but we can one approach that calculating the size of content at the appearing event with GeometryReader in background.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Further clear and intuitive API for the Carbon component in the SwiftUI.

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->
Remove `Component.intrinsicContentSize(for:)` added in RC5

## Screenshots (if appropriate)
N/A