### PR TITLE
Update DifferenceKit and enable library evolution mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
           - 11.1
         destination:
           - platform=iOS Simulator,name=iPhone 11 Pro,OS=13.1
-          - platform=iOS Simulator,name=iPhone SE,OS=10.0
+          # GitHub actions is now unsupported iOS10 simulator.
+          # - platform=iOS Simulator,name=iPhone SE,OS=10.0
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ra1028/DifferenceKit" "1.1.3"
+github "ra1028/DifferenceKit" "1.1.4"

--- a/Sources/AnyComponent.swift
+++ b/Sources/AnyComponent.swift
@@ -21,7 +21,6 @@ public struct AnyComponent: Component {
     ///
     /// - Parameters:
     ///   - base: A component to be wrap.
-    @inlinable
     public init<Base: Component>(_ base: Base) {
         if let anyComponent = base as? AnyComponent {
             self = anyComponent
@@ -180,7 +179,7 @@ internal struct ComponentBox<Base: Component>: AnyComponentBox {
         return baseComponent.reuseIdentifier
     }
 
-    @inlinable
+    @usableFromInline
     init(_ base: Base) {
         baseComponent = base
     }

--- a/Sources/ComponentWrapper/IdentifiedComponentWrapper.swift
+++ b/Sources/ComponentWrapper/IdentifiedComponentWrapper.swift
@@ -11,7 +11,6 @@ public struct IdentifiedComponentWrapper<ID: Hashable, Wrapped: Component>: Comp
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - wrapped: A compoennt instance to be wrapped.
-    @inlinable
     public init(id: ID, wrapped: Wrapped) {
         self.id = id
         self.wrapped = wrapped
@@ -24,7 +23,6 @@ public extension Component {
     ///   - id: An identifier to be wrapped.
     ///
     /// - Returns: An identified component wrapping `self` and given `id`.
-    @inlinable
     func identified<ID: Hashable>(by id: ID) -> IdentifiedComponentWrapper<ID, Self> {
         return IdentifiedComponentWrapper(id: id, wrapped: self)
     }
@@ -34,7 +32,6 @@ public extension Component {
     ///   - keyPath: A key path to access an identifier of the `self`.
     ///
     /// - Returns: An identified component wrapping `self` and the `id` that accessed by given key path.
-    @inlinable
     func identified<ID: Hashable>(by keyPath: KeyPath<Self, ID>) -> IdentifiedComponentWrapper<ID, Self> {
         return identified(by: self[keyPath: keyPath])
     }

--- a/Sources/FunctionBuilder/Group.swift
+++ b/Sources/FunctionBuilder/Group.swift
@@ -24,7 +24,6 @@ extension Group: CellsBuildable where Element == CellNode {
     ///
     /// - Parameter
     ///   - cells: A closure that constructs cells.
-    @inlinable
     public init<C: CellsBuildable>(@CellsBuilder cells: () -> C) {
         elements = cells().buildCells()
     }
@@ -34,7 +33,6 @@ extension Group: CellsBuildable where Element == CellNode {
     /// - Parameter
     ///   - data: The sequence of elements to be mapped to cells.
     ///   - cell: A closure to create a cell with passed element.
-    @inlinable
     public init<Data: Sequence, C: CellsBuildable>(of data: Data, cell: (Data.Element) -> C) {
         elements = data.flatMap { element in
             cell(element).buildCells()
@@ -44,7 +42,6 @@ extension Group: CellsBuildable where Element == CellNode {
     /// Build an array of cell.
     ///
     /// - Returns: An array of cell.
-    @inlinable
     public func buildCells() -> [CellNode] {
         elements
     }
@@ -55,7 +52,6 @@ extension Group: SectionsBuildable where Element == Section {
     ///
     /// - Parameter
     ///   - sections: A closure that constructs sections.
-    @inlinable
     public init<S: SectionsBuildable>(@SectionsBuilder sections: () -> S) {
         elements = sections().buildSections()
     }
@@ -65,7 +61,6 @@ extension Group: SectionsBuildable where Element == Section {
     /// - Parameter
     ///   - data: The sequence of elements to be mapped to sections.
     ///   - section: A closure to create a section with passed element.
-    @inlinable
     public init<Data: Sequence, S: SectionsBuildable>(of data: Data, section: (Data.Element) -> S) {
         elements = data.flatMap { element in
             section(element).buildSections()
@@ -75,7 +70,6 @@ extension Group: SectionsBuildable where Element == Section {
     /// Build an array of section.
     ///
     /// - Returns: An array of section.
-    @inlinable
     public func buildSections() -> [Section] {
         elements
     }

--- a/Sources/Nodes/CellNode.swift
+++ b/Sources/Nodes/CellNode.swift
@@ -16,7 +16,6 @@ public struct CellNode {
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - component: A component to be wrapped.
-    @inlinable
     public init<I: Hashable, C: Component>(id: I, _ component: C) {
         // This is workaround for avoid redundant `AnyHashable` wrapping.
         if type(of: id) == AnyHashable.self {

--- a/Sources/Nodes/ViewNode.swift
+++ b/Sources/Nodes/ViewNode.swift
@@ -11,7 +11,6 @@ public struct ViewNode {
     ///
     /// - Parameter
     ///   - component: A component to be wrap.
-    @inlinable
     public init<C: Component>(_ component: C) {
         self.component = AnyComponent(component)
     }
@@ -20,7 +19,6 @@ public struct ViewNode {
     ///
     /// - Parameter: An expected type of the base instance of component to casted.
     /// - Returns: A casted base instance.
-    @inlinable
     public func component<T>(as _: T.Type) -> T? {
         return component.as(T.self)
     }

--- a/Sources/Section.swift
+++ b/Sources/Section.swift
@@ -42,7 +42,6 @@ public struct Section {
     ///   - header: A node for header view.
     ///   - cells: A collection of nodes for cells.
     ///   - footer: A node for footer view.
-    @inlinable
     public init<I: Hashable, C: Swift.Collection>(id: I, header: ViewNode? = nil, cells: C, footer: ViewNode? = nil) where C.Element == CellNode {
         // This is workaround for avoid redundant `AnyHashable` wrapping.
         if type(of: id) == AnyHashable.self {
@@ -66,7 +65,6 @@ public struct Section {
     ///   - header: A node for header view.
     ///   - cells: A collection of nodes for cells that can be contains nil.
     ///   - footer: A node for footer view.
-    @inlinable
     public init<I: Hashable, C: Swift.Collection>(id: I, header: ViewNode? = nil, cells: C, footer: ViewNode? = nil) where C.Element == CellNode? {
         self.init(
             id: id,
@@ -82,7 +80,6 @@ public struct Section {
     ///   - id: An identifier to be wrapped.
     ///   - header: A node for header view.
     ///   - footer: A node for footer view.
-    @inlinable
     public init<I: Hashable>(id: I, header: ViewNode? = nil, footer: ViewNode? = nil) {
         self.init(
             id: id,
@@ -97,7 +94,6 @@ public struct Section {
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - cells: A closure that constructs cells.
-    @inlinable
     public init<I: Hashable, C: CellsBuildable>(id: I, @CellsBuilder cells: () -> C) {
         self.init(
             id: id,
@@ -112,7 +108,6 @@ public struct Section {
     ///   - header: A header component.
     ///   - footer: A footer component.
     ///   - cells: A closure that constructs cells.
-    @inlinable
     public init<I: Hashable, H: Component, F: Component, C: CellsBuildable>(id: I, header: H?, footer: F?, @CellsBuilder cells: () -> C) {
         self.init(
             id: id,
@@ -128,7 +123,6 @@ public struct Section {
     ///   - id: An identifier to be wrapped.
     ///   - header: A header component.
     ///   - footer: A footer component.
-    @inlinable
     public init<I: Hashable, H: Component, F: Component>(id: I, header: H?, footer: F?) {
         self.init(
             id: id,
@@ -143,7 +137,6 @@ public struct Section {
     ///   - id: An identifier to be wrapped.
     ///   - header: A header component.
     ///   - cells: A closure that constructs cells.
-    @inlinable
     public init<I: Hashable, H: Component>(id: I, header: H?, @CellsBuilder cells: () -> CellsBuildable) {
         self.init(
             id: id,
@@ -158,7 +151,6 @@ public struct Section {
     ///   - id: An identifier to be wrapped.
     ///   - footer: A footer component.
     ///   - cells: A closure that constructs cells.
-    @inlinable
     public init<I: Hashable, F: Component, C: CellsBuildable>(id: I, footer: F?, @CellsBuilder cells: () -> C) {
         self.init(
             id: id,
@@ -172,7 +164,6 @@ public struct Section {
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - header: A header component.
-    @inlinable
     public init<I: Hashable, H: Component>(id: I, header: H?) {
         self.init(
             id: id,
@@ -185,7 +176,6 @@ public struct Section {
     /// - Parameters:
     ///   - id: An identifier to be wrapped.
     ///   - footer: A footer component.
-    @inlinable
     public init<I: Hashable, F: Component>(id: I, footer: F?) {
         self.init(
             id: id,

--- a/XCConfigs/Carbon.xcconfig
+++ b/XCConfigs/Carbon.xcconfig
@@ -17,3 +17,4 @@ DYLIB_CURRENT_VERSION = 1
 DYLIB_INSTALL_NAME_BASE = @rpath
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/Frameworks @loader_path/../Frameworks
 DEFINES_MODULE = NO
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Update DifferenceKit version.
Enable library evolution mode by setting `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update DifferrenceKit to solve the issue that can't use carbon binary that building with Carthage if use DifferenceKit version 1.1.4.
And, Use library evolution mode to support module stability.

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->
DifferenceKit version updates.
