### PR TITLE
Work around canImport(Combine) being broken in Xcode 13

### DIFF
--- a/Sources/SwiftUISupport/ComponentSwiftUISupport.swift
+++ b/Sources/SwiftUISupport/ComponentSwiftUISupport.swift
@@ -1,4 +1,4 @@
-#if canImport(SwiftUI) && canImport(Combine)
+#if canImport(SwiftUI) && !(os(iOS) && (arch(i386) || arch(arm)))
 
 import SwiftUI
 

--- a/Tests/SwiftUISupport/ComponentSwiftUISupportTests.swift
+++ b/Tests/SwiftUISupport/ComponentSwiftUISupportTests.swift
@@ -1,4 +1,4 @@
-#if canImport(SwiftUI) && canImport(Combine)
+#if canImport(SwiftUI) && !(os(iOS) && (arch(i386) || arch(arm)))
 
 import XCTest
 import SwiftUI


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/Carbon/pulls) for ensure not duplicated.  

## Description

When using Carbon in Xcode 13, an error occurs during archiving.  
Same fix as Realm, Alamofire, etc.
https://github.com/realm/realm-cocoa/pull/7401
